### PR TITLE
SVC stub, 16 KB page sizes, signals completionEvent

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'kotlin-kapt'
     id 'idea'
     id 'com.google.dagger.hilt.android'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.1.10'
 }
 
 idea.module {
@@ -58,10 +59,9 @@ android {
 
     buildTypes {
         release {
-            debuggable true
             externalNativeBuild {
                 cmake {
-                    arguments "-DCMAKE_BUILD_TYPE=RELEASE"
+                    arguments("-DCMAKE_BUILD_TYPE=RELEASE", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
                 }
             }
             minifyEnabled true
@@ -75,7 +75,7 @@ android {
             debuggable true
             externalNativeBuild {
                 cmake {
-                    arguments "-DCMAKE_BUILD_TYPE=RELWITHDEBINFO"
+                    arguments("-DCMAKE_BUILD_TYPE=RELWITHDEBINFO", "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
                 }
             }
             minifyEnabled false

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
@@ -76,7 +76,7 @@ namespace skyline::gpu {
         try {
             choreographerLooper = ALooper_prepare(0);
             AChoreographer_postFrameCallback64(AChoreographer_getInstance(), reinterpret_cast<AChoreographer_frameCallback64>(&ChoreographerCallback), this);
-            while (ALooper_pollOnce(-1, nullptr, nullptr, nullptr) == ALOOPER_POLL_WAKE && !choreographerStop); // Will block and process callbacks till ALooper_wake() is called with choreographerStop set
+            while (ALooper_pollAll(-1, nullptr, nullptr, nullptr) == ALOOPER_POLL_WAKE && !choreographerStop); // Will block and process callbacks till ALooper_wake() is called with choreographerStop set
         } catch (const signal::SignalException &e) {
             LOGE("{}\nStack Trace:{}", e.what(), state.loader->GetStackTrace(e.frames));
             if (state.process)

--- a/app/src/main/cpp/skyline/kernel/svc.cpp
+++ b/app/src/main/cpp/skyline/kernel/svc.cpp
@@ -959,6 +959,8 @@ namespace skyline::kernel::svc {
             // 6.0.0+
             TotalMemoryAvailableWithoutSystemResource = 21,
             TotalMemoryUsageWithoutSystemResource = 22,
+            // 18.0.0+
+            AliasRegionExtraSize = 28
         };
 
         InfoState info{static_cast<u32>(ctx.w1)};
@@ -1052,6 +1054,10 @@ namespace skyline::kernel::svc {
 
             case InfoState::UserExceptionContextAddr:
                 out = reinterpret_cast<u64>(state.process->tlsExceptionContext);
+                break;
+
+            case InfoState::AliasRegionExtraSize:
+                out = 0; // Stubbed
                 break;
 
             default:

--- a/app/src/main/cpp/skyline/services/friends/IFriendService.cpp
+++ b/app/src/main/cpp/skyline/services/friends/IFriendService.cpp
@@ -12,6 +12,7 @@ namespace skyline::service::friends {
         KHandle handle{state.process->InsertItem(completionEvent)};
         LOGD("Friend Completion Event Handle: 0x{:X}", handle);
 
+        completionEvent->Signal();
         response.copyHandles.push_back(handle);
         return {};
     }

--- a/app/src/main/java/org/stratoemu/strato/MainViewModel.kt
+++ b/app/src/main/java/org/stratoemu/strato/MainViewModel.kt
@@ -32,7 +32,7 @@ class MainViewModel @Inject constructor(@ApplicationContext context : Context, p
 
     private var state
         get() = _stateData.value
-        set(value) = _stateData.postValue(value)
+        set(value) = _stateData.postValue(value!!)
     private val _stateData = MutableLiveData<MainState>()
     val stateData : LiveData<MainState> = _stateData
 


### PR DESCRIPTION
# Added
- Adds a stub for `AliasRegionExtraSize` to `SVC::GetInfo` (18.0.0+)
- Adds support for 16 KB page sizes (not fully tested)

# Changed
- Signals `completionEvent` in `IFriendService::GetCompletionEvent`